### PR TITLE
clear s:user_data after (omni)completion.

### DIFF
--- a/R/common_global.vim
+++ b/R/common_global.vim
@@ -3538,6 +3538,7 @@ endfunction
 
 function OnCompleteDone()
     call CloseFloatWin()
+    let s:user_data = {}
 endfunction
 
 let s:user_data = {}


### PR DESCRIPTION
Reset `s:user_data` to {}, after exiting completion menu, so that new completions will not contain previous data.

Refer #548